### PR TITLE
Remove InetAddress.getByName lookup for compare

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/failover/FailoverUriPool.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/failover/FailoverUriPool.java
@@ -312,25 +312,8 @@ public class FailoverUriPool {
         }
 
         if (first.getPort() == second.getPort()) {
-            InetAddress firstAddr = null;
-            InetAddress secondAddr = null;
-            try {
-                firstAddr = InetAddress.getByName(first.getHost());
-                secondAddr = InetAddress.getByName(second.getHost());
-
-                if (firstAddr.equals(secondAddr)) {
-                    result = true;
-                }
-            } catch (IOException e) {
-                if (firstAddr == null) {
-                    LOG.error("Failed to Lookup INetAddress for URI[ " + first + " ] : " + e);
-                } else {
-                    LOG.error("Failed to Lookup INetAddress for URI[ " + second + " ] : " + e);
-                }
-
-                if (first.getHost().equalsIgnoreCase(second.getHost())) {
-                    result = true;
-                }
+            if (first.getHost().equalsIgnoreCase(second.getHost())) {
+                result = true;
             }
         }
 


### PR DESCRIPTION
URIs should be able to resolve to the same IP address, as the brokers may be running behind a proxy.

For example, I have a container-based broker setup running in Kubernetes and I am exposing the brokers through the use of Kubernetes ingress (OpenShift Routes, to be exact). The brokers have different route URIs but they always will resolve back to the HAProxy running as a load balancer in front of the Kubernetes cluster. 

Example: failover:(amqps://ex-aao-amqp-2-svc-rte-amq-broker.apps.ocp.domain.com:443,amqps://ex-aao-amqp-0-svc-rte-amq-broker.apps.ocp.domain.com:443)

Both ex-aao-amqp-0-svc-rte-amq-broker.apps.ocp.domain.com and ex-aao-amqp-2-svc-rte-amq-broker.apps.ocp.domain.com will both resolve to the exact same IP address because those addresses resolve to the HAProxy running in front of OpenShift. 

The new logic ignores the ultimately resolved IP addresses as the comparison method and instead simply compares the equality of the strings.
